### PR TITLE
Parse all "flags" from a comment event

### DIFF
--- a/packages/autotest/src/github/GitHubUtil.ts
+++ b/packages/autotest/src/github/GitHubUtil.ts
@@ -73,13 +73,23 @@ export class GitHubUtil {
         return parsedDelivId;
     }
 
-    public static parseCommandFromComment(message: any, cmd: string): boolean {
+    public static parseCommandFromComment(message: string, cmd: string): boolean {
         if (message.indexOf(`#${cmd}`) >= 0) {
             Log.trace(`GitHubUtil::parseCommandFromComment() - input: ${message}; ${cmd}: true`);
             return true;
         }
         Log.trace(`GitHubUtil::parseCommandFromComment() - input: ${message}; ${cmd}: false`);
         return false;
+    }
+
+    public static parseAllCommandsFromComment(message: string): string[] {
+        const flags = new Set(message.match(/#[a-zA-Z0-9]+/g) || []);
+        for (const command of ['force', 'silent', 'check', 'schedule', 'unschedule']) {
+            if (GitHubUtil.parseCommandFromComment(message, command)) {
+                flags.add(`#${command}`);
+            }
+        }
+        return [...flags];
     }
 
     /**
@@ -115,12 +125,7 @@ export class GitHubUtil {
 
             Log.info("GitHubUtil::processComment(..) - 2");
 
-            const flags: string[] = [];
-            for (const command of ['force', 'silent', 'check', 'schedule', 'unschedule']) {
-                if (GitHubUtil.parseCommandFromComment(message, command)) {
-                    flags.push(`#${command}`);
-                }
-            }
+            const flags: string[] = GitHubUtil.parseAllCommandsFromComment(message);
 
             const botName = "@" + Config.getInstance().getProp(ConfigKey.botName).toLowerCase();
             const botMentioned: boolean = message.toLowerCase().indexOf(botName) >= 0;

--- a/packages/autotest/src/github/GitHubUtil.ts
+++ b/packages/autotest/src/github/GitHubUtil.ts
@@ -73,23 +73,8 @@ export class GitHubUtil {
         return parsedDelivId;
     }
 
-    public static parseCommandFromComment(message: string, cmd: string): boolean {
-        if (message.indexOf(`#${cmd}`) >= 0) {
-            Log.trace(`GitHubUtil::parseCommandFromComment() - input: ${message}; ${cmd}: true`);
-            return true;
-        }
-        Log.trace(`GitHubUtil::parseCommandFromComment() - input: ${message}; ${cmd}: false`);
-        return false;
-    }
-
-    public static parseAllCommandsFromComment(message: string): string[] {
-        const flags = new Set(message.match(/#[a-zA-Z0-9]+/g) || []);
-        for (const command of ['force', 'silent', 'check', 'schedule', 'unschedule']) {
-            if (GitHubUtil.parseCommandFromComment(message, command)) {
-                flags.add(`#${command}`);
-            }
-        }
-        return [...flags];
+    public static parseCommandsFromComment(message: string): string[] {
+        return [...new Set(message.match(/#[a-zA-Z0-9]+/g) || [])];
     }
 
     /**
@@ -125,7 +110,7 @@ export class GitHubUtil {
 
             Log.info("GitHubUtil::processComment(..) - 2");
 
-            const flags: string[] = GitHubUtil.parseAllCommandsFromComment(message);
+            const flags: string[] = GitHubUtil.parseCommandsFromComment(message);
 
             const botName = "@" + Config.getInstance().getProp(ConfigKey.botName).toLowerCase();
             const botMentioned: boolean = message.toLowerCase().indexOf(botName) >= 0;

--- a/packages/autotest/test/GitHubUtilSpec.ts
+++ b/packages/autotest/test/GitHubUtilSpec.ts
@@ -39,56 +39,23 @@ describe("GitHubUtil", () => {
         expect(actual).to.equal("a1");
     });
 
-    it("Should be able to correctly parse #silent from a commit comment.", () => {
-        let actual;
-
-        actual = GitHubUtil.parseCommandFromComment("@ubcbot #d1", 'silent');
-        expect(actual).to.be.false;
-
-        actual = GitHubUtil.parseCommandFromComment("@ubcbot d1", 'silent');
-        expect(actual).to.be.false;
-
-        actual = GitHubUtil.parseCommandFromComment("@ubcbot #d101 #silent", 'silent');
-        expect(actual).to.be.true;
-
-        actual = GitHubUtil.parseCommandFromComment("@ubcbot #silent.", 'silent');
-        expect(actual).to.be.true;
-    });
-
-    it("Should be able to correctly parse #force from a commit comment.", () => {
-        let actual;
-
-        actual = GitHubUtil.parseCommandFromComment("@ubcbot #d1", 'force');
-        expect(actual).to.be.false;
-
-        actual = GitHubUtil.parseCommandFromComment("@ubcbot d1", 'force');
-        expect(actual).to.be.false;
-
-        actual = GitHubUtil.parseCommandFromComment("@ubcbot #d101 #silent #force", 'force');
-        expect(actual).to.be.true;
-
-        actual = GitHubUtil.parseCommandFromComment("@ubcbot #force.", 'force');
-        expect(actual).to.be.true;
-    });
-
     it("Should be able to find extra commands from a commit comment.", () => {
         let actual;
 
-        actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot #d1 #verbose");
+        actual = GitHubUtil.parseCommandsFromComment("@ubcbot #d1 #verbose");
         expect(actual).to.deep.equal(["#d1", "#verbose"]);
 
-        actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot d1 verbose ## # ###");
+        actual = GitHubUtil.parseCommandsFromComment("@ubcbot d1 verbose ## # ###");
         expect(actual).to.deep.equal([]);
 
-        actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot #d101 #silent #force #verbose");
+        actual = GitHubUtil.parseCommandsFromComment("@ubcbot #d101 #silent #force #verbose");
         expect(actual).to.deep.equal(["#d101", "#silent", "#force", "#verbose"]);
 
-        actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot #force. #verbose. #force #silent\n");
+        actual = GitHubUtil.parseCommandsFromComment("@ubcbot #force. #verbose. #force #silent\n");
         expect(actual).to.deep.equal(["#force", "#verbose", "#silent"]);
 
-        // This assumes that silent is one of the base required commands
-        actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot #silentbutwithmoreattheend");
-        expect(actual).to.deep.equal(["#silentbutwithmoreattheend", "#silent"]);
+        actual = GitHubUtil.parseCommandsFromComment("@ubcbot #forcefoo");
+        expect(actual).to.deep.equal(["#forcefoo"]);
     });
 
     it("Should be able to correctly create human durations", () => {

--- a/packages/autotest/test/GitHubUtilSpec.ts
+++ b/packages/autotest/test/GitHubUtilSpec.ts
@@ -85,6 +85,10 @@ describe("GitHubUtil", () => {
 
         actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot #force. #verbose. #force #silent\n");
         expect(actual).to.deep.equal(["#force", "#verbose", "#silent"]);
+
+        // This assumes that silent is one of the base required commands
+        actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot #silentbutwithmoreattheend");
+        expect(actual).to.deep.equal(["#silentbutwithmoreattheend", "#silent"]);
     });
 
     it("Should be able to correctly create human durations", () => {

--- a/packages/autotest/test/GitHubUtilSpec.ts
+++ b/packages/autotest/test/GitHubUtilSpec.ts
@@ -71,6 +71,22 @@ describe("GitHubUtil", () => {
         expect(actual).to.be.true;
     });
 
+    it("Should be able to find extra commands from a commit comment.", () => {
+        let actual;
+
+        actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot #d1 #verbose");
+        expect(actual).to.deep.equal(["#d1", "#verbose"]);
+
+        actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot d1 verbose ## # ###");
+        expect(actual).to.deep.equal([]);
+
+        actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot #d101 #silent #force #verbose");
+        expect(actual).to.deep.equal(["#d101", "#silent", "#force", "#verbose"]);
+
+        actual = GitHubUtil.parseAllCommandsFromComment("@ubcbot #force. #verbose. #force #silent\n");
+        expect(actual).to.deep.equal(["#force", "#verbose", "#silent"]);
+    });
+
     it("Should be able to correctly create human durations", () => {
         const now = Date.now();
         const oneSecond = now - 1000;


### PR DESCRIPTION
This should allow for anything that looks like a flag to get saved in the comment event.
This should allow for more custom flags to be created as the CommitTarget is now passed to the grading container. This opens up options like `#verbose` or `#trace` which would allow us to control the logging in the grading container from a comment event.