### PR TITLE
Adding in TLS updates

### DIFF
--- a/packages/proxy/nginx.rconf
+++ b/packages/proxy/nginx.rconf
@@ -17,8 +17,25 @@ http {
         # this is supposed to turn off access logging but is _not_ working (crashes proxy)
         # access_log /dev/null
 
+        ssl_session_timeout 1d;
+        ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+        ssl_session_tickets off;
+
+        ssl_protocols          TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
+
+        # HSTS (ngx_http_headers_module is required) (63072000 seconds)
+        add_header Strict-Transport-Security "max-age=63072000" always;
+
+        # OCSP stapling
+        ssl_stapling on;
+        ssl_stapling_verify on;
+
         ssl_certificate        <%= ENV["SSL_CERT_PATH"] %>;
         ssl_certificate_key    <%= ENV["SSL_KEY_PATH"] %>;
+
+        resolver 127.0.0.1;
 
         location /ui {
             port_in_redirect   off;  # Don't redirect to 8443 (https://serverfault.com/q/227742)


### PR DESCRIPTION
The main requirements for this PR from my end are that TLS 1.0 and 1.1 is disabled and that the cipher options are limited to strong and conventional ciphers due to security. However, other minor improvements were implemented.

The full list of implemented features are:

- Limits cipher options for Https
- Eliminates use of TLS 1.0 and 1.1
- Uses TLS 1.2 as standard
- Some session expiry implemented
- Ensures DNS resolver is server VM localhost
- Enables SSL stapling

If anyone would like some configuration taken out, please let me know. I do not mind meeting in the middle. The above is based on recommendations from Mozilla (https://ssl-config.mozilla.org/). 