### PR TITLE
Remove codeshovel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,6 @@ services:
         depends_on:
             - portal
             - reference_ui
-            - codeshovelui
             - labcycleui
         ports:
             - "80:8080"
@@ -110,30 +109,6 @@ services:
             - ${UI_PORT}
         restart: always
         user: "${UID}"
-    codeshovelwebservice:
-        build:
-            context: https://${LC_GITHUB_TOKEN}@github.com/braxtonhall/codeshovel-webservice.git
-        container_name: codeshovelwebservice
-        expose:
-        - 8080
-        restart: always
-        environment:
-        - GITHUB_TOKEN=${LC_GITHUB_TOKEN}
-        volumes:
-        - "${CODESHOVEL_LOG_PATH}:/requests.csv"
-        - "${CODESHOVEL_CACHE_PATH}:/cache"
-    codeshovelui:
-        build:
-            args:
-            - "SERVER_ADDRESS=${PUBLICHOSTNAME}/codeshovelserver"
-            - "PUBLIC_ADDRESS=${PUBLICHOSTNAME}/codeshovel"
-            context: https://${LC_GITHUB_TOKEN}@github.com/braxtonhall/codeshovel-ui.git
-        container_name: codeshovelui
-        depends_on:
-        - codeshovelwebservice
-        expose:
-        - 5000
-        restart: always
     labcyclewebservice:
         build:
             context: https://${LC_GITHUB_TOKEN}@github.com/braxtonhall/labcycle.git

--- a/packages/proxy/nginx.rconf
+++ b/packages/proxy/nginx.rconf
@@ -45,20 +45,6 @@ http {
             proxy_pass         http://refui:<%= ENV["UI_PORT"] %>/;
         }
 
-        location /codeshovel {
-            port_in_redirect   off;
-            rewrite            /codeshovel(/.+) $1 break;
-            proxy_read_timeout 240;
-            proxy_pass         http://codeshovelui:5000;
-        }
-
-        location /codeshovelserver {
-            port_in_redirect   off;
-            rewrite            /codeshovelserver(/.+) $1 break;
-            proxy_read_timeout 240;
-            proxy_pass         http://codeshovelwebservice:8080;
-        }
-
         location /labs {
             port_in_redirect   off;
             rewrite            /labs(/.+) $1 break;
@@ -72,13 +58,6 @@ http {
             proxy_read_timeout 240;
             proxy_pass         http://labcyclewebservice:4321;
         }
-
-        # location /pl {
-        #     port_in_redirect   off;
-        #     rewrite            /pl(/.+) $1 break;
-        #     proxy_read_timeout 240;
-        #     proxy_pass         http://prairielearn:3000;
-        # }
 
         # pass requests to the portal service (which is automatically defined in the hosts file by docker)
         location / {


### PR DESCRIPTION
Codeshovel doesn't build properly anymore, and should be hosted on se.cs.ubc.ca anyway