### PR TITLE
Remove docker control flags from output

### DIFF
--- a/packages/autotest/src/autotest/GradingJob.ts
+++ b/packages/autotest/src/autotest/GradingJob.ts
@@ -100,7 +100,7 @@ export class GradingJob {
 
         const stdio = fs.createWriteStream(this.path + "/staff/stdio.txt");
         const stream = await container.attach({stream: true, stdout: true, stderr: true});
-        stream.pipe(stdio);
+        container.modem.demuxStream(stream, stdio, stdio);
 
         const exitCode = await GradingJob.runContainer(container, maxExecTime);
 


### PR DESCRIPTION
Not sure how this got lost, but this change was merged in #50 
Do you know if this was purposefully reverted?

I suspect it's because we didn't want to upstream the other changes to GradingJob.ts (which I'm just now realising were also lost on this fork)