### PR TITLE
Hotfix/use http for patches

### DIFF
--- a/packages/portal/backend/src/controllers/GitHubController.ts
+++ b/packages/portal/backend/src/controllers/GitHubController.ts
@@ -1,4 +1,4 @@
-import * as https from "https";
+import * as http from "http";
 import fetch, {RequestInit} from "node-fetch";
 
 import Config, {ConfigKey} from "../../../../common/Config";
@@ -389,7 +389,7 @@ export class GitHubController implements IGitHubController {
 
         const options: RequestInit = {
             method:             'POST',
-            agent:              new https.Agent({ rejectUnauthorized: false })
+            agent:              new http.Agent()
         };
 
         let result;

--- a/packages/portal/backend/src/server/common/AdminRoutes.ts
+++ b/packages/portal/backend/src/server/common/AdminRoutes.ts
@@ -1,5 +1,5 @@
 import * as cookie from 'cookie';
-import * as https from 'https';
+import * as http from 'http';
 import fetch, {RequestInit} from "node-fetch";
 import * as restify from 'restify';
 
@@ -1232,7 +1232,7 @@ export default class AdminRoutes implements IREST {
         const url = Config.getInstance().getProp(ConfigKey.patchToolUrl) + "/update";
         const opts: RequestInit = {
             method:             'post',
-            agent:              new https.Agent({ rejectUnauthorized: false })
+            agent:              new http.Agent()
         };
         fetch(url, opts)
             .then((result) => {
@@ -1251,7 +1251,7 @@ export default class AdminRoutes implements IREST {
         const url = Config.getInstance().getProp(ConfigKey.patchToolUrl) + "/patches";
         const opts: RequestInit = {
             method:             'get',
-            agent:              new https.Agent({ rejectUnauthorized: false })
+            agent:              new http.Agent()
         };
 
         fetch(url, opts).then(async (result) => {


### PR DESCRIPTION
Reject unauthorized doesn't work with node-fetch, although https shouldn't have been used in the first place.
Been running this on cs310.students for the last week so gonna give it the ol merge once the checks are done running.