### PR TITLE
Admin stdio toggle

### DIFF
--- a/packages/portal/frontend/html/stdio.html
+++ b/packages/portal/frontend/html/stdio.html
@@ -16,6 +16,11 @@
 <ons-page id="stdioPage">
     <ons-toolbar>
         <div class="center" id="headerTitle">Container Output Viewer</div>
+        <div id='indexLogin' class="right">
+            <ons-toolbar-button id="switchViewBtn">
+                <span id="switchViewText"style="vertical-align: top; font-size: 80%;">Admin View</span>
+            </ons-toolbar-button>
+        </div>
     </ons-toolbar>
     <div style="height: 100%; display:flex; align-items:center; justify-content: center;">
         <div id="stdioViewer">Loading...</div>
@@ -68,8 +73,8 @@
             return vars;
         }
 
-        function loadStdio(delivId, repoId, sha) {
-            var url = HOST + 'portal/resource/' + sha + '-' + delivId + '/staff/stdio.txt';
+        function loadStdio(delivId, repoId, sha, stdioType) {
+            var url = HOST + 'portal/resource/' + sha + '-' + delivId + '/' + stdioType + '/stdio.txt';
             getHTTP(url, HEADERS, function (stdio) {
                 editor.setValue(stdio);
                 editor.clearSelection();
@@ -161,9 +166,27 @@
         editor.setReadOnly(true);
 
         // asyncs
-        loadStdio(delivId, repoId, sha);
+        loadStdio(delivId, repoId, sha, 'staff');
         loadNotPassingTestNames(delivId, repoId, sha);
+
+        // switchViewBtn
+        var switchViewBtn = document.getElementById('switchViewBtn');
+        switchViewBtn.addEventListener('click', (event) => {
+            var btnLabel = event.target.innerText;
+            editor.setValue('Loading...');
+            if (btnLabel.startsWith('Admin')) {
+                loadStdio(delivId, repoId, sha, 'admin');
+                loadNotPassingTestNames(delivId, repoId, sha);
+                event.target.innerText = 'Staff View';
+            } else {
+                loadStdioT(delivId, repoId, sha, 'staff');
+                loadNotPassingTestNamesT(delivId, repoId, sha);
+                event.target.innerText = 'Admin View';
+            }
+        });
+
     });
+    
 </script>
 
 </body>

--- a/packages/portal/frontend/html/stdio.html
+++ b/packages/portal/frontend/html/stdio.html
@@ -16,7 +16,7 @@
 <ons-page id="stdioPage">
     <ons-toolbar>
         <div class="center" id="headerTitle">Container Output Viewer</div>
-        <div id='indexLogin' class="right">
+        <div id='stdioSwitch' class="right">
             <ons-toolbar-button id="switchViewBtn">
                 <span id="switchViewText"style="vertical-align: top; font-size: 80%;">Admin View</span>
             </ons-toolbar-button>
@@ -169,21 +169,25 @@
         loadStdio(delivId, repoId, sha, 'staff');
         loadNotPassingTestNames(delivId, repoId, sha);
 
-        // switchViewBtn
+        // switchViewBtn: only enable the admin/staff stdio switch btn when the user is an admin
         var switchViewBtn = document.getElementById('switchViewBtn');
-        switchViewBtn.addEventListener('click', (event) => {
-            var btnLabel = event.target.innerText;
-            editor.setValue('Loading...');
-            if (btnLabel.startsWith('Admin')) {
-                loadStdio(delivId, repoId, sha, 'admin');
-                loadNotPassingTestNames(delivId, repoId, sha);
-                event.target.innerText = 'Staff View';
-            } else {
-                loadStdioT(delivId, repoId, sha, 'staff');
-                loadNotPassingTestNamesT(delivId, repoId, sha);
-                event.target.innerText = 'Admin View';
-            }
-        });
+        if (localStorage.getItem('isAdmin') !== 'true') {
+            switchViewBtn.disabled = true;
+        } else {
+            switchViewBtn.addEventListener('click', (event) => {
+                var btnLabel = event.target.innerText;
+                editor.setValue('Loading...');
+                if (btnLabel.startsWith('Admin')) {
+                    event.target.innerText = 'Staff View';
+                    loadStdio(delivId, repoId, sha, 'admin');
+                    loadNotPassingTestNames(delivId, repoId, sha);
+                } else {
+                    event.target.innerText = 'Admin View';
+                    loadStdio(delivId, repoId, sha, 'staff');
+                    loadNotPassingTestNames(delivId, repoId, sha);
+                }
+            });
+        }
 
     });
     

--- a/packages/portal/frontend/html/stdio.html
+++ b/packages/portal/frontend/html/stdio.html
@@ -74,7 +74,7 @@
         }
 
         function loadStdio(delivId, repoId, sha, stdioType) {
-            var url = HOST + 'portal/resource/' + sha + '-' + delivId + '/' + stdioType + '/stdio.txt';
+            const url = `${HOST}/portal/resource/${sha}-${delivId}/${stdioType}/stdio.txt`;
             getHTTP(url, HEADERS, function (stdio) {
                 editor.setValue(stdio);
                 editor.clearSelection();
@@ -132,7 +132,7 @@
         }
 
         function loadNotPassingTestNames(delivId, repoId, sha) {
-            var url = HOST + '/portal/admin/dashboard/' + delivId + '/' + repoId;
+            const url = `${HOST}/portal/admin/dashboard/${delivId}/${repoId}`;
             getHTTP(url, HEADERS, function (data) {
                 json = JSON.parse(data);
                 var commit = json['success']
@@ -171,9 +171,7 @@
 
         // switchViewBtn: only enable the admin/staff stdio switch btn when the user is an admin
         var switchViewBtn = document.getElementById('switchViewBtn');
-        if (localStorage.getItem('isAdmin') !== 'true') {
-            switchViewBtn.disabled = true;
-        } else {
+        function handleSwitchStdio() {
             switchViewBtn.addEventListener('click', (event) => {
                 var btnLabel = event.target.innerText;
                 editor.setValue('Loading...');
@@ -187,6 +185,12 @@
                     loadNotPassingTestNames(delivId, repoId, sha);
                 }
             });
+        }
+
+        if (localStorage.getItem('isAdmin') !== 'true') {
+            switchViewBtn.disabled = true;
+        } else {
+            handleSwitchStdio();
         }
 
     });


### PR DESCRIPTION
The stdio page defaults to pulling from `staff/stdio.txt` on load. The admin stdio toggle should be enabled if the user is logged in as an admin, otherwise the button remain disabled. When `staff/stdio.txt` is loaded, the button should be labelled as "Admin View", and when `admin/stdio.txt` is loaded, the button should be labelled as "Staff View".

Unrelated question to the issue: is the extra slash between `HOST` and `'/portal/admin/dashboard'` in the url for `loadNotPassingTestNames()` added on purpose (compare w/ the similar url position for `loadStdio()`)? If not, should I remove the extra / in the PR as well?